### PR TITLE
Use Logger class instead of puts-ing and allow configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -408,9 +408,7 @@ Now don't forget to go back to your Facebook developer console and change the ad
 
 ## Coming next
 
-* Proper implementation of logging (for now it's just `p` and `puts` statements sprinkled around the code) with ability to choose a logging level.
-
-* More powerful DSL for parsing user input and binding it to commands.   
+* More powerful DSL for parsing user input and binding it to commands.
 
 * NLP integration with Wit.AI (that allow for more things then the built-in NLP capabilities of Messenger platform, including a wrapper around Wit's interactive learning methods) is in the works and will be added to the gem some time in 2018...
 

--- a/lib/rubotnik/helpers.rb
+++ b/lib/rubotnik/helpers.rb
@@ -63,10 +63,10 @@ module Rubotnik
       @message.typing_off
       case response.code
       when 200
-        puts "Data received from Graph API: #{response.body}" # logging
+        Rubotnik.logger.info "Data received from Graph API: #{response.body}" # logging
         return JSON.parse(response.body, symbolize_names: true)
       else
-        puts "Request failed: #{response.body}"
+        Rubotnik.logger.info "Request failed: #{response.body}"
         return false
       end
     end

--- a/lib/rubotnik/message_dispatch.rb
+++ b/lib/rubotnik/message_dispatch.rb
@@ -20,7 +20,7 @@ module Rubotnik
       if @user.current_command
         command = @user.current_command
         execute(command)
-        puts "Command #{command} is executed for user #{@user.id}"
+        Rubotnik.logger.info "Command #{command} is executed for user #{@user.id}"
       else
         bind_commands(&block)
       end
@@ -54,20 +54,20 @@ module Rubotnik
 
     def handle_command(to, reply_with)
       if reply_with.empty?
-        puts "Command #{to} is executed for user #{@user.id}"
+        Rubotnik.logger.info "Command #{to} is executed for user #{@user.id}"
         execute(to)
         @user.reset_command
-        puts "Command is reset for user #{@user.id}"
+        Rubotnik.logger.info "Command is reset for user #{@user.id}"
       else
         say(reply_with[:text], quick_replies: reply_with[:quick_replies])
         @user.assign_command(to)
-        puts "Command #{to} is set for user #{@user.id}"
+        Rubotnik.logger.info "Command #{to} is set for user #{@user.id}"
       end
     end
 
     def default
       return if @matched
-      puts 'None of the commands were recognized' # log
+      Rubotnik.logger.info 'None of the commands were recognized'
       yield
       @user.reset_command
     end

--- a/lib/rubotnik/postback_dispatch.rb
+++ b/lib/rubotnik/postback_dispatch.rb
@@ -31,7 +31,7 @@ module Rubotnik
       return unless @postback.payload == regex_string.upcase
       clear_user_state
       @matched = true
-      puts "Matched #{regex_string} to #{to.nil? ? 'block' : to}"
+      Rubotnik.logger.info "Matched #{regex_string} to #{to.nil? ? 'block' : to}"
       if block_given?
         yield
         return
@@ -42,13 +42,13 @@ module Rubotnik
     def handle_command(to, reply_with)
       if reply_with.empty?
         execute(to)
-        puts "Command #{to} is executed for user #{@user.id}"
+        Rubotnik.logger.info "Command #{to} is executed for user #{@user.id}"
         @user.reset_command
-        puts "Command is reset for user #{@user.id}"
+        Rubotnik.logger.info "Command is reset for user #{@user.id}"
       else
         say(reply_with[:message], quick_replies: reply_with[:quick_replies])
         @user.assign_command(to)
-        puts "Command #{to} is set for user #{@user.id}"
+        Rubotnik.logger.info "Command #{to} is set for user #{@user.id}"
       end
     end
 

--- a/lib/rubotnik/user_store.rb
+++ b/lib/rubotnik/user_store.rb
@@ -17,18 +17,18 @@ class Rubotnik::UserStore
     @users << user
     user = @users.last
     if user
-      p "user #{user.inspect} added to store"
-      p "we got #{@users.count} users: #{@users}"
+      Rubotnik.logger.info "user #{user.inspect} added to store"
+      Rubotnik.logger.info "we got #{@users.count} users: #{@users}"
     else
-      p 'user not found in store yet'
+      Rubotnik.logger.info 'user not found in store yet'
     end
     user
   end
 
   def find(id)
     user = @users.find { |u| u.id == id }
-    p "user #{user} found in store" if user
-    p "we got #{@users.count} users: #{@users}" if user
+    Rubotnik.logger.info "user #{user} found in store" if user
+    Rubotnik.logger.info "we got #{@users.count} users: #{@users}" if user
     user
   end
 end

--- a/spec/rubotnik_spec.rb
+++ b/spec/rubotnik_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe Rubotnik do
     expect(Rubotnik::VERSION).not_to be nil
   end
 
+  describe 'logger' do
+    it 'allows logging' do
+      described_class.logger.info 'aaaa'
+    end
+
+    it 'allows overriding the logger' do
+      logger_double = double(:logger)
+      described_class.logger = logger_double
+      expect(logger_double).to receive(:info)
+      described_class.logger.info 'xxx'
+    end
+  end
+
   describe 'subscribe' do
     it 'subscribes to a fb page' do
       token = 'xxx'


### PR DESCRIPTION
It'll now be possible to use custom loggers by doing e.g.

`Rubotnik.logger = Log4r.Logger`

default logger outputs to stdout

closes https://github.com/progapandist/rubotnik/issues/14